### PR TITLE
Add rsync backup container configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:latest
+
+RUN apk add --no-cache openssh-client rsync
+
+COPY backup.sh /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/backup.sh
+
+COPY crontab /etc/crontabs/root
+
+CMD ["crond", "-f", "-L", "/dev/stdout"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Remote Backup Container
+
+Este reposit\u00f3rio fornece uma imagem Docker leve baseada em Alpine que executa um backup di\u00e1rio via `rsync`.
+
+O backup copia o conte\u00fado de `/data/source` para o servidor remoto `10.18.19.2` usando a chave SSH do host.
+
+## Estrutura do projeto
+
+- **Dockerfile** - Constr\u00f3i a imagem com `rsync` e `openssh-client`, copia o script de backup e configura o `cron`.
+- **backup.sh** - Script que valida a conex\u00e7\u00e3o SSH e executa o `rsync`.
+- **crontab** - Agenda a execu\u00e7\u00e3o di\u00e1ria \u00e0s 3h da manh\u00e3.
+- **docker-compose.yml** - Facilita a cria\u00e7\u00e3o do container e o mapeamento de volumes.
+
+## Uso r\u00e1pido
+
+1. Copie os dados que deseja sincronizar para `./data/source`.
+2. Certifique-se de possuir uma chave SSH em `~/.ssh/id_ed25519` com acesso ao host de destino.
+3. Construa e inicialize o container:
+
+   ```bash
+   docker compose up --build -d
+   ```
+
+O container executar\u00e1 diariamente o `backup.sh`, registrando a sa\u00edda no console.
+
+## Personaliza\u00e7\u00e3o
+
+Ajuste as vari\u00e1veis `REMOTE_HOST` e `REMOTE_PATH` no `backup.sh` conforme o destino desejado.
+

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+REMOTE_HOST="10.18.19.2"
+REMOTE_PATH="/mnt/user/backups/zbox"
+SOURCE="/data/source/"
+DEST="root@${REMOTE_HOST}:${REMOTE_PATH}"
+
+printf '%s - Validating SSH connectivity to %s...\n' "$(date)" "$REMOTE_HOST"
+if ! ssh -i /root/.ssh/id_ed25519 -o BatchMode=yes -o ConnectTimeout=10 root@${REMOTE_HOST} true; then
+  printf '%s - ERROR: Unable to connect to %s via SSH.\n' "$(date)" "$REMOTE_HOST" >&2
+  exit 1
+fi
+
+printf '%s - Starting rsync...\n' "$(date)"
+rsync -avz --delete -e "ssh -i /root/.ssh/id_ed25519" "$SOURCE" "$DEST"

--- a/crontab
+++ b/crontab
@@ -1,0 +1,1 @@
+0 3 * * * /usr/local/bin/backup.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  backup:
+    build: .
+    container_name: remote-backup
+    volumes:
+      - ./data/source:/data/source:ro
+      - ${HOME}/.ssh:/root/.ssh:ro


### PR DESCRIPTION
## Summary
- add Dockerfile for Alpine-based cron container
- add rsync backup script
- schedule daily run at 3 AM via cron
- provide docker-compose.yml for easy setup
- document usage in README

## Testing
- `bash -n backup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883e67e59108321800e2074650a843f