### PR TITLE
Atualizar documentacao generica

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,23 @@
 
 Este reposit\u00f3rio fornece uma imagem Docker leve baseada em Alpine que executa um backup di\u00e1rio via `rsync`.
 
-O backup copia o conte\u00fado de `/data/source` para o servidor remoto `10.18.19.2` usando a chave SSH do host.
+O backup copia o conteudo de `/data/source` para um servidor remoto configurado pelo usuario usando a chave SSH do host.
 
 ## Estrutura do projeto
 
 - **Dockerfile** - Constr\u00f3i a imagem com `rsync` e `openssh-client`, copia o script de backup e configura o `cron`.
-- **backup.sh** - Script que valida a conex\u00e7\u00e3o SSH e executa o `rsync`.
+- **backup.sh** - Script que valida a conex\u00e7\u00e3o SSH e executa o `rsync`,
+  lendo as vari\u00e1veis definidas em `backup.conf`.
 - **crontab** - Agenda a execu\u00e7\u00e3o di\u00e1ria \u00e0s 3h da manh\u00e3.
 - **docker-compose.yml** - Facilita a cria\u00e7\u00e3o do container e o mapeamento de volumes.
+- **backup.conf** - Arquivo de configura\u00e7\u00e3o com as vari\u00e1veis de ambiente utilizadas pelo `backup.sh`.
 
 ## Uso r\u00e1pido
 
 1. Copie os dados que deseja sincronizar para `./data/source`.
-2. Certifique-se de possuir uma chave SSH em `~/.ssh/id_ed25519` com acesso ao host de destino.
-3. Construa e inicialize o container:
+2. Ajuste o arquivo `backup.conf` com o host e caminho remotos desejados.
+3. Certifique-se de possuir uma chave SSH em `~/.ssh/id_ed25519` com acesso ao host de destino.
+4. Construa e inicialize o container:
 
    ```bash
    docker compose up --build -d
@@ -25,5 +28,5 @@ O container executar\u00e1 diariamente o `backup.sh`, registrando a sa\u00edda n
 
 ## Personaliza\u00e7\u00e3o
 
-Ajuste as vari\u00e1veis `REMOTE_HOST` e `REMOTE_PATH` no `backup.sh` conforme o destino desejado.
+Edite o arquivo `backup.conf` para definir as variaveis `REMOTE_HOST` e `REMOTE_PATH` conforme seu ambiente. Os valores do repositorio sao apenas exemplos. O arquivo e montado no container e lido automaticamente pelo `backup.sh` a cada execucao.
 

--- a/backup.conf
+++ b/backup.conf
@@ -1,0 +1,4 @@
+# Hostname or IP of the remote server
+REMOTE_HOST=example.com
+# Target directory on the remote server
+REMOTE_PATH=/path/to/remote/backup

--- a/backup.sh
+++ b/backup.sh
@@ -1,9 +1,20 @@
 #!/bin/sh
 set -e
 
-REMOTE_HOST="10.18.19.2"
-REMOTE_PATH="/mnt/user/backups/zbox"
+# Load configuration file if available. The default location
+# can be overridden via the CONFIG_FILE environment variable.
+CONFIG_FILE="${CONFIG_FILE:-/config/backup.conf}"
+if [ -f "$CONFIG_FILE" ]; then
+  # shellcheck source=/dev/null
+  . "$CONFIG_FILE"
+fi
+
 SOURCE="/data/source/"
+
+# Ensure required variables are defined.
+: "${REMOTE_HOST:?Missing REMOTE_HOST}"
+: "${REMOTE_PATH:?Missing REMOTE_PATH}"
+
 DEST="root@${REMOTE_HOST}:${REMOTE_PATH}"
 
 printf '%s - Validating SSH connectivity to %s...\n' "$(date)" "$REMOTE_HOST"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,4 @@ services:
     volumes:
       - ./data/source:/data/source:ro
       - ${HOME}/.ssh:/root/.ssh:ro
+      - ./backup.conf:/config/backup.conf:ro


### PR DESCRIPTION
## Summary
- retirar IP fixo do README e usar explicacao generica
- avisar que variaveis no `backup.conf` sao apenas exemplos
- usar valores genericos em `backup.conf`

## Testing
- `sh -n backup.sh`
- `docker compose config` *(falha: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6883e851ac2c83218539ad05c4b0e8e9