### PR TITLE
Set unlimited backup retention default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Remote Backup Container
 
-Este reposit\u00f3rio fornece uma imagem Docker leve baseada em Alpine que executa um backup di\u00e1rio. Cada subpasta de `/data/source` é compactada em um arquivo `tar.gz` datado e transferida via `rsync`.
+ Este reposit\u00f3rio fornece uma imagem Docker leve baseada em Alpine que executa um backup di\u00e1rio. Cada subpasta de `/data/source` \u00e9 compactada em um arquivo `tar.gz` datado e transferida via `rsync`. O destino pode manter um n\u00famero configur\u00e1vel de arquivos por subpasta, removendo os mais antigos quando `BACKUP_KEEP` for maior que zero. O padr\u00e3o \u00e9 `0`, indicando que n\u00e3o h\u00e1 limite e nada \u00e9 apagado.
 
 ## Estrutura do projeto
 
@@ -26,5 +26,5 @@ O container executar\u00e1 diariamente o `backup.sh`, que compacta cada subpasta
 
 ## Personaliza\u00e7\u00e3o
 
-Edite o arquivo `backup.conf` para definir as variaveis `REMOTE_HOST` e `REMOTE_PATH` conforme seu ambiente. Os valores do repositorio sao apenas exemplos. O arquivo e montado no container e lido automaticamente pelo `backup.sh` a cada execucao.
+Edite o arquivo `backup.conf` para definir as vari\u00e1veis `REMOTE_HOST` e `REMOTE_PATH`, al\u00e9m de `BACKUP_KEEP` caso deseje alterar a quantidade de arquivos preservados por subpasta. O valor padr\u00e3o \u00e9 `0`, indicando que n\u00e3o h\u00e1 limite. Os valores do reposit\u00f3rio s\u00e3o apenas exemplos. O arquivo \u00e9 montado no container e lido automaticamente pelo `backup.sh` a cada execu\u00e7\u00e3o.
 

--- a/backup.conf
+++ b/backup.conf
@@ -2,3 +2,5 @@
 REMOTE_HOST=10.18.19.2
 # Target directory on the remote server
 REMOTE_PATH=/mnt/user/backups/zbox
+# Number of backups to keep for each subfolder. 0 means unlimited
+BACKUP_KEEP=0

--- a/backup.sh
+++ b/backup.sh
@@ -17,6 +17,12 @@ SOURCE="/data/source"
 
 DEST="root@${REMOTE_HOST}:${REMOTE_PATH}"
 
+# Number of backups to keep per subfolder. Older archives will be
+# deleted after each new backup when this value is greater than zero.
+# Can be set via BACKUP_KEEP or in the configuration file. Defaults to 0
+# meaning unlimited retention.
+BACKUP_KEEP="${BACKUP_KEEP:-0}"
+
 SSH_DIR="/root/.ssh"
 if [ -z "${SSH_KEY_FILE}" ]; then
   SSH_KEY_FILE=$(find "$SSH_DIR" -maxdepth 1 -type f -name 'id_*' ! -name '*.pub' 2>/dev/null | head -n 1 || true)
@@ -28,13 +34,13 @@ if [ ! -f "$SSH_KEY_FILE" ]; then
 fi
 
 printf '%s - Validating SSH connectivity to %s using %s...\n' "$(date)" "$REMOTE_HOST" "$SSH_KEY_FILE"
-if ! ssh -i "$SSH_KEY_FILE" -o BatchMode=yes -o ConnectTimeout=10 root@${REMOTE_HOST} true; then
+if ! ssh -i "$SSH_KEY_FILE" -o BatchMode=yes -o ConnectTimeout=10 "root@${REMOTE_HOST}" true; then
   printf '%s - ERROR: Unable to connect to %s via SSH.\n' "$(date)" "$REMOTE_HOST" >&2
   exit 1
 fi
 
 printf '%s - Ensuring remote directory %s exists...\n' "$(date)" "$REMOTE_PATH"
-ssh -i "$SSH_KEY_FILE" root@${REMOTE_HOST} "mkdir -p \"${REMOTE_PATH}\""
+ssh -i "$SSH_KEY_FILE" "root@${REMOTE_HOST}" "mkdir -p \"${REMOTE_PATH}\""
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -47,4 +53,10 @@ for dir in "$SOURCE"/*; do
   tar -czf "$archive" -C "$SOURCE" "$base"
   printf '%s - Transferring %s to %s...\n' "$(date)" "$archive" "$DEST/"
   rsync -avz -e "ssh -i ${SSH_KEY_FILE}" "$archive" "$DEST/"
+
+  if [ "$BACKUP_KEEP" -gt 0 ]; then
+    printf '%s - Pruning old backups for %s, keeping %s files...\n' "$(date)" "$base" "$BACKUP_KEEP"
+    ssh -i "$SSH_KEY_FILE" "root@${REMOTE_HOST}" \
+      "cd \"${REMOTE_PATH}\" && ls -1 ${base}_*.tar.gz 2>/dev/null | sort | head -n -${BACKUP_KEEP} | xargs -r rm -f"
+  fi
 done


### PR DESCRIPTION
## Summary
- keep no limit of archives when `BACKUP_KEEP=0`
- document that `BACKUP_KEEP` defaults to 0 for unlimited retention

## Testing
- `apt-get update`
- `apt-get install -y xxd shellcheck`
- `shellcheck backup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6884ff86950483218c46abef2a13b25f