### PR TITLE
Add configurable cron schedule via entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache openssh-client rsync
 COPY backup.sh /usr/local/bin/backup.sh
 RUN chmod +x /usr/local/bin/backup.sh
 
-COPY crontab /etc/crontabs/root
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
-CMD ["crond", "-f", "-L", "/dev/stdout"]
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ## Estrutura do projeto
 
-- **Dockerfile** - Constr\u00f3i a imagem com `rsync` e `openssh-client`, copia o script de backup e configura o `cron`.
+- **Dockerfile** - Constr\u00f3i a imagem com `rsync` e `openssh-client`, copia o script de backup e o entrypoint que configura o `cron`.
 - **backup.sh** - Script que valida a conex\u00e7\u00e3o SSH, compacta cada subpasta e transfere os arquivos usando `rsync`,
   lendo as vari\u00e1veis definidas em `backup.conf`.
-- **crontab** - Agenda a execu\u00e7\u00e3o di\u00e1ria \u00e0s 3h da manh\u00e3.
+- **entrypoint.sh** - Configura o `cron` usando a vari\u00e1vel `CRON_SCHEDULE` e inicia o servi\u00e7o.
 - **docker-compose.yml** - Facilita a cria\u00e7\u00e3o do container e o mapeamento de volumes.
 - **backup.conf** - Arquivo de configura\u00e7\u00e3o com as vari\u00e1veis de ambiente utilizadas pelo `backup.sh`.
 
@@ -27,4 +27,6 @@ O container executar\u00e1 diariamente o `backup.sh`, que compacta cada subpasta
 ## Personaliza\u00e7\u00e3o
 
 Edite o arquivo `backup.conf` para definir as vari\u00e1veis `REMOTE_HOST`, `REMOTE_PATH` e opcionalmente `REMOTE_USER`, al\u00e9m de `BACKUP_KEEP` caso deseje alterar a quantidade de arquivos preservados por subpasta. O valor padr\u00e3o \u00e9 `0`, indicando que n\u00e3o h\u00e1 limite. A vari\u00e1vel `REMOTE_USER` assume `root` quando n\u00e3o definida. Os valores do reposit\u00f3rio s\u00e3o apenas exemplos. O arquivo \u00e9 montado no container e lido automaticamente pelo `backup.sh` a cada execu\u00e7\u00e3o.
+
+Tamb\u00e9m \u00e9 poss\u00edvel ajustar a frequ\u00eancia de execu\u00e7\u00e3o definindo a vari\u00e1vel de ambiente `CRON_SCHEDULE`. O padr\u00e3o \u00e9 `0 3 * * *`, que significa diariamente \u00e0s 3h da manh\u00e3. Essa vari\u00e1vel pode ser alterada no `docker-compose.yml` ou no momento de iniciar o container.
 

--- a/crontab
+++ b/crontab
@@ -1,1 +1,0 @@
-0 3 * * * /usr/local/bin/backup.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   backup:
     build: .
     container_name: remote-backup
+    environment:
+      CRON_SCHEDULE: ${CRON_SCHEDULE:-"0 3 * * *"}
     volumes:
       - ${HOME}:/data/source:ro
       - ./.ssh:/root/.ssh:ro

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+SCHEDULE="${CRON_SCHEDULE:-0 3 * * *}"
+
+echo "$SCHEDULE /usr/local/bin/backup.sh" > /etc/crontabs/root
+
+exec crond -f -L /dev/stdout


### PR DESCRIPTION
## Summary
- replace static `crontab` with an entrypoint script that reads `CRON_SCHEDULE`
- expose `CRON_SCHEDULE` variable in `docker-compose.yml`
- document cron schedule configuration in README
- update Dockerfile to use the new entrypoint
- remove old crontab file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68850d028adc8321a7f150d8ea2bba54